### PR TITLE
Game Scoring Rules fix to use same values as other SDKs

### DIFF
--- a/model/Area.js
+++ b/model/Area.js
@@ -1,8 +1,8 @@
 function Area() {
   this.NOSE   = 'NOSE';
   this.JAW    = 'JAW';
-  this.GROIN  = 'GROIN';
   this.BELLY  = 'BELLY';
+  this.GROIN  = 'GROIN';  
   this.LEGS   = 'LEGS';
 }
 

--- a/model/GameScoringRules.js
+++ b/model/GameScoringRules.js
@@ -3,8 +3,8 @@ var Area = require('./Area');
 function GameScoringRules() {
   this.NOSE_SCORE = 10;
   this.JAW_SCORE = 8;
-  this.GROIN_SCORE = 6;
-  this.BELLY_SCORE = 4;
+  this.BELLY_SCORE = 6;
+  this.GROIN_SCORE = 4;  
   this.LEGS_SCORE = 3;
 
   this.LIFEPOINTS = 150;


### PR DESCRIPTION
node sdk was using incorrect scoring values (belly and groin mismatched). Fixed in game scoring rules and in Area.js (for clarity)
